### PR TITLE
feat: redesign Sudoku mini-program UI and add accessibility options

### DIFF
--- a/miniprogram/pages/sudoku/index.js
+++ b/miniprogram/pages/sudoku/index.js
@@ -12,6 +12,25 @@ const ERROR_TEXT = {
   E_UNSOLVABLE: '当前盘面无解'
 };
 
+const DIFFICULTY_OPTIONS = [
+  { value: 'easy', label: '简单' },
+  { value: 'medium', label: '中等' },
+  { value: 'hard', label: '困难' }
+];
+
+function createCellBorderStyles() {
+  return Array.from({ length: 81 }, (_, index) => {
+    const row = Math.floor(index / 9);
+    const col = index % 9;
+    const top = row % 3 === 0 ? 4 : 1;
+    const left = col % 3 === 0 ? 4 : 1;
+    const right = col === 8 ? 4 : 1;
+    const bottom = row === 8 ? 4 : 1;
+
+    return `border-top-width:${top}rpx;border-left-width:${left}rpx;border-right-width:${right}rpx;border-bottom-width:${bottom}rpx;`;
+  });
+}
+
 Page({
   data: {
     grid: Array(81).fill(0),
@@ -20,14 +39,23 @@ Page({
     conflicts: [],
     candidatesPanel: [],
     difficulty: 'easy',
-    statusText: '准备开始',
+    difficultyLabel: '简单',
+    difficultyOptions: DIFFICULTY_OPTIONS,
+    difficultyIndex: 0,
+    statusText: '继续加油！',
     elapsedSec: 0,
     mistakeCount: 0,
-    isSolved: false
+    isSolved: false,
+    largeText: false,
+    bigButtons: false,
+    highContrast: false,
+    numbers: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    cellBorderStyle: createCellBorderStyles()
   },
 
   onLoad() {
     this.game = new SudokuGame();
+    this.restoreSettings();
     this.onTapNewGame();
   },
 
@@ -45,46 +73,73 @@ Page({
 
   onTapCell(e) {
     const index = Number(e.currentTarget.dataset.index);
-    const state = this.game.getState();
-    const candidatesPanel = state ? (state.grid[index] === 0 ? require('../../lib/sudoku').getCandidates(state.grid, index) : []) : [];
-    this.setData({ selectedIndex: index, candidatesPanel });
+    this.setData({ selectedIndex: index });
   },
 
   onInputNumber(e) {
     const value = Number(e.currentTarget.dataset.value);
     const { selectedIndex } = this.data;
-    if (selectedIndex < 0) return;
+    if (selectedIndex < 0) {
+      this.setData({ statusText: '请先点击一个格子' });
+      return;
+    }
     const result = this.game.input(selectedIndex, value);
-    this.syncFromResult(result);
+    this.syncFromResult(result, '继续加油！');
   },
 
   onTapErase() {
     const { selectedIndex } = this.data;
-    if (selectedIndex < 0) return;
+    if (selectedIndex < 0) {
+      this.setData({ statusText: '请先点击一个格子' });
+      return;
+    }
     const result = this.game.erase(selectedIndex);
-    this.syncFromResult(result);
+    this.syncFromResult(result, '已清除当前格');
   },
 
   onTapCheck() {
     const result = this.game.check();
     if (!result.ok) return this.showError(result.code);
-    const statusText = result.isSolved ? '恭喜通关！' : result.conflicts.length ? '存在冲突，请检查红色格子' : '当前无冲突';
+    const statusText = result.isSolved ? '恭喜通关！' : result.conflicts.length ? '存在冲突，请检查红色格子' : '当前无冲突，继续加油！';
     this.setData({ conflicts: result.conflicts, statusText, isSolved: result.isSolved });
   },
 
   onTapHint() {
     const result = this.game.hint();
-    this.syncFromResult(result, '已填入提示格');
+    this.syncFromResult(result, '已填入一个提示格');
   },
 
   onTapSolve() {
     const result = this.game.solve();
-    this.syncFromResult(result, '已展示答案');
+    this.syncFromResult(result, '已显示答案，可以再玩一局！');
+  },
+
+  onDifficultyChange(e) {
+    const index = Number(e.detail.value);
+    const selected = DIFFICULTY_OPTIONS[index] || DIFFICULTY_OPTIONS[0];
+    this.setData({
+      difficultyIndex: index,
+      difficulty: selected.value,
+      difficultyLabel: selected.label
+    });
+    this.onTapNewGame();
   },
 
   onTapNewGame() {
     const result = this.game.newGame({ difficulty: this.data.difficulty });
-    this.syncFromResult(result, '新局已开始');
+    this.syncFromResult(result, '新游戏开始啦！');
+  },
+
+  toggleLargeText() {
+    this.setData({ largeText: !this.data.largeText });
+  },
+
+  toggleBigButtons() {
+    this.setData({ bigButtons: !this.data.bigButtons });
+  },
+
+  toggleHighContrast() {
+    this.setData({ highContrast: !this.data.highContrast });
   },
 
   syncFromResult(result, successText) {
@@ -97,7 +152,7 @@ Page({
       elapsedSec: state.elapsedSec,
       mistakeCount: state.mistakeCount,
       isSolved: state.isSolved,
-      statusText: successText || (state.isSolved ? '恭喜通关！' : '进行中')
+      statusText: successText || (state.isSolved ? '恭喜通关！' : '继续加油！')
     });
   },
 
@@ -109,7 +164,38 @@ Page({
     const saved = this.game.serialize();
     if (saved.ok) {
       wx.setStorageSync(GAME_STATE_KEY, saved.data);
-      wx.setStorageSync(SETTINGS_KEY, JSON.stringify({ difficulty: this.data.difficulty }));
+      wx.setStorageSync(SETTINGS_KEY, JSON.stringify({
+        difficulty: this.data.difficulty,
+        difficultyIndex: this.data.difficultyIndex,
+        largeText: this.data.largeText,
+        bigButtons: this.data.bigButtons,
+        highContrast: this.data.highContrast
+      }));
+    }
+  },
+
+  restoreSettings() {
+    const raw = wx.getStorageSync(SETTINGS_KEY);
+    if (!raw) return;
+
+    try {
+      const settings = JSON.parse(raw);
+      const difficultyIndex = typeof settings.difficultyIndex === 'number'
+        ? settings.difficultyIndex
+        : DIFFICULTY_OPTIONS.findIndex(item => item.value === settings.difficulty);
+      const safeIndex = difficultyIndex >= 0 ? difficultyIndex : 0;
+      const selected = DIFFICULTY_OPTIONS[safeIndex];
+
+      this.setData({
+        difficulty: selected.value,
+        difficultyIndex: safeIndex,
+        difficultyLabel: selected.label,
+        largeText: Boolean(settings.largeText),
+        bigButtons: Boolean(settings.bigButtons),
+        highContrast: Boolean(settings.highContrast)
+      });
+    } catch (error) {
+      // ignore bad cache
     }
   },
 

--- a/miniprogram/pages/sudoku/index.json
+++ b/miniprogram/pages/sudoku/index.json
@@ -1,3 +1,3 @@
 {
-  "navigationBarTitleText": "数独"
+  "navigationBarTitleText": "数独库游戏"
 }

--- a/miniprogram/pages/sudoku/index.wxml
+++ b/miniprogram/pages/sudoku/index.wxml
@@ -1,24 +1,50 @@
-<view class="sudoku-page">
-  <view class="status">{{statusText}}</view>
-  <view class="grid">
-    <block wx:for="{{grid}}" wx:key="index">
-      <view
-        class="cell {{givensMask[index] ? 'given' : ''}} {{conflicts.indexOf(index) > -1 ? 'conflict' : ''}} {{selectedIndex === index ? 'selected' : ''}}"
-        data-index="{{index}}"
-        bindtap="onTapCell"
-      >{{item === 0 ? '' : item}}</view>
-    </block>
+<view class="sudoku-page {{largeText ? 'large-text' : ''}} {{highContrast ? 'high-contrast' : ''}}">
+  <view class="hero">
+    <view class="hero-title">🧩 数独库游戏</view>
+    <view class="hero-desc">选择难度后开始游戏，填写数字 1-9，点击提示可自动填一个格子。</view>
   </view>
-  <view class="panel">
-    <view class="numbers">
-      <block wx:for="{{[1,2,3,4,5,6,7,8,9]}}" wx:key="*this">
-        <button size="mini" data-value="{{item}}" bindtap="onInputNumber">{{item}}</button>
+
+  <view class="feature-chips">
+    <view class="chip {{largeText ? 'active' : ''}}" bindtap="toggleLargeText">👓 大字模式</view>
+    <view class="chip {{bigButtons ? 'active' : ''}}" bindtap="toggleBigButtons">✋ 按钮更大</view>
+    <view class="chip {{highContrast ? 'active' : ''}}" bindtap="toggleHighContrast">🌈 高对比度</view>
+  </view>
+
+  <view class="action-row {{bigButtons ? 'big' : ''}}">
+    <view class="row-label">🎯 难度</view>
+    <picker mode="selector" range="{{difficultyOptions}}" range-key="label" value="{{difficultyIndex}}" bindchange="onDifficultyChange">
+      <view class="action-btn picker-btn">{{difficultyLabel}}</view>
+    </picker>
+    <button class="action-btn" bindtap="onTapNewGame">🆕 新游戏</button>
+  </view>
+
+  <view class="action-row {{bigButtons ? 'big' : ''}}">
+    <button class="action-btn" bindtap="onTapCheck">✅ 检查</button>
+    <button class="action-btn" bindtap="onTapHint">💡 提示</button>
+    <button class="action-btn" bindtap="onTapSolve">📘 显示答案</button>
+  </view>
+
+  <view class="status-box">{{statusText}}</view>
+
+  <view class="grid-wrap">
+    <view class="grid">
+      <block wx:for="{{grid}}" wx:key="index">
+        <view
+          class="cell {{givensMask[index] ? 'given' : ''}} {{conflicts.indexOf(index) > -1 ? 'conflict' : ''}} {{selectedIndex === index ? 'selected' : ''}} {{(Math.floor(index / 9) + Math.floor((index % 9) / 3)) % 2 === 0 ? 'shade' : ''}}"
+          style="{{cellBorderStyle[index]}}"
+          data-index="{{index}}"
+          bindtap="onTapCell"
+        >
+          {{item === 0 ? '' : item}}
+        </view>
       </block>
     </view>
-    <button bindtap="onTapErase">擦除</button>
-    <button bindtap="onTapCheck">检查</button>
-    <button bindtap="onTapHint">提示</button>
-    <button bindtap="onTapSolve">答案</button>
-    <button bindtap="onTapNewGame">新局</button>
+  </view>
+
+  <view class="number-pad {{bigButtons ? 'big' : ''}}">
+    <block wx:for="{{numbers}}" wx:key="*this">
+      <button class="number-btn" data-value="{{item}}" bindtap="onInputNumber">{{item}}</button>
+    </block>
+    <button class="number-btn erase" bindtap="onTapErase">⌫</button>
   </view>
 </view>

--- a/miniprogram/pages/sudoku/index.wxss
+++ b/miniprogram/pages/sudoku/index.wxss
@@ -1,9 +1,208 @@
-.sudoku-page { padding: 24rpx; }
-.status { margin-bottom: 16rpx; color: #333; }
-.grid { display: grid; grid-template-columns: repeat(9, 1fr); gap: 4rpx; }
-.cell { height: 68rpx; line-height: 68rpx; text-align: center; background: #fafafa; border: 1rpx solid #ddd; }
-.cell.given { font-weight: 700; color: #222; background: #f0f4ff; }
-.cell.conflict { color: #d93025; background: #ffe8e6; }
-.cell.selected { border-color: #1a73e8; }
-.panel { margin-top: 18rpx; }
-.numbers { display: grid; grid-template-columns: repeat(9, 1fr); gap: 6rpx; margin-bottom: 12rpx; }
+page {
+  background: #f3f5fb;
+}
+
+.sudoku-page {
+  padding: 24rpx;
+  color: #17223b;
+}
+
+.hero {
+  margin-bottom: 28rpx;
+}
+
+.hero-title {
+  font-size: 72rpx;
+  line-height: 1.2;
+  font-weight: 800;
+  margin-bottom: 16rpx;
+}
+
+.hero-desc {
+  color: #4a5568;
+  font-size: 46rpx;
+  line-height: 1.45;
+}
+
+.feature-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16rpx;
+  margin-bottom: 26rpx;
+}
+
+.chip {
+  border: 4rpx solid #d89a1b;
+  background: #fff7da;
+  color: #6d3d00;
+  border-radius: 999rpx;
+  padding: 12rpx 24rpx;
+  font-size: 48rpx;
+  font-weight: 700;
+}
+
+.chip.active {
+  background: #ffe7a6;
+}
+
+.action-row {
+  display: flex;
+  align-items: center;
+  gap: 14rpx;
+  margin-bottom: 14rpx;
+}
+
+.row-label {
+  font-size: 58rpx;
+  font-weight: 700;
+  min-width: 130rpx;
+}
+
+.action-btn {
+  flex: 1;
+  height: 90rpx;
+  border-radius: 20rpx;
+  border: 3rpx solid #c4ccd8;
+  background: #ffffff;
+  color: #111827;
+  font-size: 46rpx;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0 20rpx;
+}
+
+.action-btn::after {
+  border: none;
+}
+
+.status-box {
+  margin: 20rpx 0;
+  background: #dbe1ef;
+  border-radius: 18rpx;
+  padding: 22rpx;
+  font-size: 50rpx;
+  font-weight: 700;
+  color: #1b2a4b;
+}
+
+.grid-wrap {
+  background: #fff;
+  border-radius: 20rpx;
+  overflow: hidden;
+  box-shadow: 0 6rpx 24rpx rgba(12, 31, 61, 0.08);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+}
+
+.cell {
+  height: 70rpx;
+  line-height: 70rpx;
+  text-align: center;
+  border: 1rpx solid #c7d0dd;
+  font-size: 48rpx;
+  font-weight: 700;
+  color: #0f1b34;
+  background: #fff;
+}
+
+.cell.shade {
+  background: #eef2fa;
+}
+
+.cell.given {
+  font-weight: 800;
+}
+
+.cell.conflict {
+  color: #c53030;
+  background: #ffe5e5;
+}
+
+.cell.selected {
+  box-shadow: inset 0 0 0 4rpx #2b6ef3;
+  background: #fff;
+}
+
+.number-pad {
+  margin-top: 20rpx;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 10rpx;
+}
+
+.number-btn {
+  height: 80rpx;
+  border-radius: 14rpx;
+  border: 2rpx solid #bcc6d6;
+  background: #fff;
+  color: #162137;
+  font-size: 42rpx;
+  font-weight: 700;
+  margin: 0;
+  padding: 0;
+}
+
+.number-btn::after {
+  border: none;
+}
+
+.number-btn.erase {
+  grid-column: span 1;
+  background: #edf2fb;
+}
+
+.sudoku-page.large-text .hero-title {
+  font-size: 82rpx;
+}
+
+.sudoku-page.large-text .hero-desc,
+.sudoku-page.large-text .chip,
+.sudoku-page.large-text .row-label,
+.sudoku-page.large-text .action-btn,
+.sudoku-page.large-text .status-box,
+.sudoku-page.large-text .cell,
+.sudoku-page.large-text .number-btn {
+  font-size: 54rpx;
+}
+
+.sudoku-page.high-contrast {
+  background: #fefae0;
+}
+
+.sudoku-page.high-contrast .chip {
+  background: #fff;
+  border-color: #000;
+  color: #000;
+}
+
+.sudoku-page.high-contrast .action-btn,
+.sudoku-page.high-contrast .number-btn,
+.sudoku-page.high-contrast .status-box,
+.sudoku-page.high-contrast .grid-wrap {
+  border-color: #000;
+  color: #000;
+}
+
+.sudoku-page.high-contrast .cell {
+  color: #000;
+  border-color: #444;
+}
+
+.sudoku-page.high-contrast .cell.selected {
+  box-shadow: inset 0 0 0 5rpx #0052cc;
+}
+
+.action-row.big .action-btn {
+  height: 106rpx;
+}
+
+.number-pad.big .number-btn {
+  height: 96rpx;
+}


### PR DESCRIPTION
### Motivation
- Align the mini-program Sudoku page with the provided mobile screenshots to improve visual hierarchy and usability.
- Add accessibility and usability options (large text, bigger buttons, high contrast) so the game is easier to use on small screens.
- Make the board visuals clearer by emphasizing 3x3 region borders and improving selected/conflict/given states for better player feedback.

### Description
- Reworked the page markup in `miniprogram/pages/sudoku/index.wxml` to add a hero (title + description), feature chips for toggles, a difficulty `picker`, grouped action buttons, a status bar, and a polished board + number pad layout.
- Rewrote styles in `miniprogram/pages/sudoku/index.wxss` to implement the new visual design including card background, capsule chips, bold 3x3 borders, shade stripes, large-text and high-contrast variants, and larger button modes.
- Enhanced logic in `miniprogram/pages/sudoku/index.js` to add `DIFFICULTY_OPTIONS`, difficulty `picker` handling, `largeText`/`bigButtons`/`highContrast` state and toggle methods, per-cell border style generation (`createCellBorderStyles()`), improved status messages, and persistent UI settings saved to `SETTINGS_KEY`.
- Updated `miniprogram/pages/sudoku/index.json` to change the navigation title to `数独库游戏`.

### Testing
- Ran unit tests with `node miniprogram/lib/sudoku/__tests__/sudoku.test.js`, which passed.
- Validated puzzle data with `node scripts/validate-sudoku-puzzles.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3656029bc8321b0aee45bf1dc1414)