### PR TITLE
Add root-level WeChat mini-game entries and `minigameRoot` for DevTools compatibility

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,0 +1,1 @@
+require('./minigame/game');

--- a/game.json
+++ b/game.json
@@ -1,0 +1,10 @@
+{
+  "deviceOrientation": "portrait",
+  "showStatusBar": "hide",
+  "networkTimeout": {
+    "request": 10000,
+    "connectSocket": 10000,
+    "uploadFile": 10000,
+    "downloadFile": 10000
+  }
+}

--- a/minigame/README.md
+++ b/minigame/README.md
@@ -8,7 +8,7 @@
 2. 项目目录请选择仓库根目录（包含 `project.config.json` 的目录），不要选 `minigame/` 子目录。
 3. 确认 `project.config.json` 中：
    - `compileType` 是 `game`
-   - `gameRoot` 是 `minigame/`
+   - `gameRoot` / `minigameRoot` 都是 `minigame/`
 4. 清缓存后重新编译：`工具 -> 清除缓存 -> 全部清除`，再点击“编译”。
 
 ## 为什么会看到“打飞机”
@@ -20,5 +20,12 @@
 - 小游戏脚本入口：`minigame/game.js`
 - 小游戏配置：`minigame/game.json`
 - 工程配置：`project.config.json`
+
+另外，仓库根目录也提供了兼容入口：
+
+- `game.js`（转发到 `minigame/game.js`）
+- `game.json`（与 `minigame/game.json` 保持一致）
+
+这是为了兼容部分版本开发者工具在自动预览时只查找根目录 `game.json` 的行为。
 
 只要按上面的方式导入，运行出来应该是“数独库小游戏”，不是“打飞机”。

--- a/project.config.json
+++ b/project.config.json
@@ -23,5 +23,6 @@
   "appid": "touristappid",
   "projectname": "sudoku-minigame",
   "gameRoot": "minigame/",
+  "minigameRoot": "minigame/",
   "condition": {}
 }


### PR DESCRIPTION
### Motivation
- Some versions of WeChat DevTools (auto-preview) look for `game.json` in the repository root causing the wrong template to be launched, so the project needs a root-level compatibility entry and an explicit alternate root key to remain discoverable.

### Description
- Add root-level `game.json` to mirror `minigame/game.json` so DevTools that scan the repo root will find the configuration file.
- Add root-level `game.js` that forwards to `./minigame/game` so the runtime entry is available at the repo root.
- Add a `minigameRoot` field in `project.config.json` alongside `gameRoot` to indicate the actual mini-game directory for toolchains that honor that key.
- Update `minigame/README.md` to document the new compatibility files and explain troubleshooting steps for the "打飞机" template issue.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('project.config.json','utf8')); JSON.parse(require('fs').readFileSync('game.json','utf8')); console.log('json ok')"` which printed `json ok` indicating the new JSON files parse successfully.
- Ran `git status --short` to verify there are no unexpected uncommitted changes after applying the updates, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c371b5f4488321b0bb2f949ebf29e0)