### PR TITLE
fix: correct game.json showStatusBar type

### DIFF
--- a/game.json
+++ b/game.json
@@ -1,6 +1,6 @@
 {
   "deviceOrientation": "portrait",
-  "showStatusBar": "hide",
+  "showStatusBar": false,
   "networkTimeout": {
     "request": 10000,
     "connectSocket": 10000,


### PR DESCRIPTION
### Motivation
- Fix a WeChat DevTools validation error caused by `game.json` having `"showStatusBar": "hide"`, which must be a boolean to avoid compile/runtime failures.

### Description
- Change `game.json` `showStatusBar` value from the string `"hide"` to the boolean `false`.

### Testing
- Verified `game.json` parses successfully with `python -c "import json; json.load(open('game.json'))"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3756556808321acba5f35ce42909e)