### PR TITLE
fix(minigame): use boolean for showStatusBar in game.json

### DIFF
--- a/minigame/game.json
+++ b/minigame/game.json
@@ -1,6 +1,6 @@
 {
   "deviceOrientation": "portrait",
-  "showStatusBar": "hide",
+  "showStatusBar": false,
   "networkTimeout": {
     "request": 10000,
     "connectSocket": 10000,


### PR DESCRIPTION
### Motivation
- Fix a WeChat Mini Game configuration schema error where `showStatusBar` was a string and must be a boolean to avoid DevTools/compile warnings.

### Description
- Changed `minigame/game.json` `showStatusBar` value from string `"hide"` to boolean `false`.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('minigame/game.json','utf8')); console.log('ok')"` and verified `git` diffs to ensure only `minigame/game.json` changed; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c376db37448321ad35a7f026a05170)