### PR TITLE
Fix minigame Sudoku import path

### DIFF
--- a/minigame/game.js
+++ b/minigame/game.js
@@ -1,4 +1,4 @@
-const { SudokuGame } = require('./lib/sudoku');
+const { SudokuGame } = require('./lib/sudoku/index');
 
 const game = new SudokuGame();
 const canvas = wx.createCanvas();


### PR DESCRIPTION
### Motivation
- Prevent runtime module resolution errors in the WeChat game subcontext that occur when requiring the `lib/sudoku` directory shorthand which can resolve to a missing `lib/sudoku.js` file.

### Description
- Replace `require('./lib/sudoku')` with the explicit `require('./lib/sudoku/index')` in `minigame/game.js` so the `SudokuGame` export is resolved reliably in the subcontext.

### Testing
- Ran `node --check minigame/game.js` which succeeded.
- Ran `node -e "const m=require('./minigame/lib/sudoku/index'); if(!m.SudokuGame) throw new Error('missing'); console.log('ok')"` which printed `ok`.
- Attempting to execute `require('./minigame/game.js')` under Node fails due to missing `wx` globals as expected for code intended for the WeChat runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c38d56f6ec83219bc6c3c468ba9468)