### PR TITLE
fix(minigame): fallback when requestAnimationFrame is unavailable

### DIFF
--- a/minigame/game.js
+++ b/minigame/game.js
@@ -223,7 +223,15 @@ function draw() {
 
 function loop() {
   draw();
-  canvas.requestAnimationFrame(loop);
+  if (canvas && typeof canvas.requestAnimationFrame === 'function') {
+    canvas.requestAnimationFrame(loop);
+    return;
+  }
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(loop);
+    return;
+  }
+  setTimeout(loop, 16);
 }
 
 adaptScreen();


### PR DESCRIPTION
### Motivation
- Prevent startup crash when `canvas.requestAnimationFrame` is not defined in some debugging/real-device environments which raised `TypeError` and broke the render loop.

### Description
- Add a safe render-loop scheduler in `minigame/game.js` that prefers `canvas.requestAnimationFrame`, falls back to the global `requestAnimationFrame`, and finally to `setTimeout(loop, 16)`.

### Testing
- Ran `node minigame/lib/sudoku/tests/sudoku.test.js` and it passed (`sudoku tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c393c7a4708321a952697696dd1a47)