### PR TITLE
fix(minigame): normalize touch coordinates to restore tap responsiveness

### DIFF
--- a/minigame/game.js
+++ b/minigame/game.js
@@ -130,6 +130,31 @@ function onTap(x, y) {
   }
 }
 
+function getTouchPoint(touch) {
+  if (!touch || typeof touch !== 'object') return null;
+  const x = Number.isFinite(touch.clientX)
+    ? touch.clientX
+    : Number.isFinite(touch.x)
+      ? touch.x
+      : Number.isFinite(touch.pageX)
+        ? touch.pageX
+        : Number.isFinite(touch.screenX)
+          ? touch.screenX
+          : NaN;
+  const y = Number.isFinite(touch.clientY)
+    ? touch.clientY
+    : Number.isFinite(touch.y)
+      ? touch.y
+      : Number.isFinite(touch.pageY)
+        ? touch.pageY
+        : Number.isFinite(touch.screenY)
+          ? touch.screenY
+          : NaN;
+
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  return { x, y };
+}
+
 function drawRoundRect(x, y, w, h, radius, color) {
   ctx.beginPath();
   ctx.moveTo(x + radius, y);
@@ -240,6 +265,7 @@ loop();
 
 wx.onTouchStart((event) => {
   const touch = event.touches[0];
-  if (!touch) return;
-  onTap(touch.clientX, touch.clientY);
+  const point = getTouchPoint(touch);
+  if (!point) return;
+  onTap(point.x, point.y);
 });


### PR DESCRIPTION
### Motivation

- Taps in the WeChat minigame could be ignored in some runtimes (Touchstone / devtools adapters) because `touch.clientX/clientY` may be absent, causing the board and keypad to appear unresponsive.

### Description

- Add `getTouchPoint` in `minigame/game.js` to normalize touch coordinates from multiple runtime-specific fields (`clientX/clientY`, `x/y`, `pageX/pageY`, `screenX/screenY`).
- Update `wx.onTouchStart` to use the normalized point and call `onTap(point.x, point.y)` only when valid coordinates are obtained.
- Keep existing hit testing and input logic unchanged; the change only improves runtime compatibility for touch coordinate extraction.

### Testing

- Ran `node minigame/lib/sudoku/tests/sudoku.test.js` and it passed. 
- Ran `node miniprogram/lib/sudoku/tests/sudoku.test.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c398809bbc8321959a2f260a6e3144)