### PR TITLE
fix: disable `useApiHook` in private configs to avoid DevTools bridge init error

### DIFF
--- a/minigame/project.private.config.json
+++ b/minigame/project.private.config.json
@@ -10,7 +10,7 @@
     "autoAudits": false,
     "showShadowRootInWxmlPanel": true,
     "compileHotReLoad": true,
-    "useApiHook": true,
+    "useApiHook": false,
     "useStaticServer": false,
     "useLanDebug": false,
     "showES6CompileOption": false,

--- a/project.private.config.json
+++ b/project.private.config.json
@@ -9,7 +9,7 @@
     "skylineRenderEnable": false,
     "preloadBackgroundData": false,
     "autoAudits": false,
-    "useApiHook": true,
+    "useApiHook": false,
     "showShadowRootInWxmlPanel": true,
     "useStaticServer": false,
     "useLanDebug": false,


### PR DESCRIPTION
### Motivation
- 在本地通过微信开发者工具调试时，DevTools 的 API Hook / VConsole 桥接会注入并产生 `WeixinJSBridge not available within 1s` 等启动报错，需在私有配置中禁用该钩子以消除这些虚假错误。

### Description
- 将私有配置 `useApiHook` 从 `true` 改为 `false`，已修改 `minigame/project.private.config.json` 和 `project.private.config.json`，仅影响本地/开发者工具行为，不改变运行时数独逻辑或线上代码。

### Testing
- 已运行 `node minigame/lib/sudoku/tests/sudoku.test.js` 和 `node scripts/validate-sudoku-puzzles.js`，两项自动化测试均通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c39d61ee4c8321884ce8df59f567fc)