### PR TITLE
fix(minigame): harden canvas init and runtime error reporting

### DIFF
--- a/minigame/game.js
+++ b/minigame/game.js
@@ -1,7 +1,14 @@
 const { SudokuGame } = require('./lib/sudoku/index');
 
 const game = new SudokuGame();
-const canvas = wx.createCanvas();
+
+function createGameCanvas() {
+  if (typeof wx.createCanvas === 'function') return wx.createCanvas();
+  if (typeof wx.createOffscreenCanvas === 'function') return wx.createOffscreenCanvas({ type: '2d' });
+  throw new Error('当前运行环境不支持 Canvas');
+}
+
+const canvas = createGameCanvas();
 const ctx = canvas.getContext('2d');
 
 let state = null;
@@ -14,6 +21,16 @@ let originX = 0;
 let originY = 0;
 let numButtons = [];
 let actionButtons = [];
+
+
+function reportRuntimeError(prefix, err) {
+  const raw = err && (err.stack || err.errMsg || err.message || String(err));
+  const message = String(raw || '').split('\n').filter(Boolean).slice(0, 2).join(' | ') || '未知错误';
+  statusText = `${prefix}: ${message}`;
+  if (typeof console !== 'undefined' && typeof console.error === 'function') {
+    console.error(`[MiniGame] ${prefix}`, err);
+  }
+}
 
 function adaptScreen() {
   const sys = wx.getSystemInfoSync();
@@ -257,6 +274,20 @@ function loop() {
     return;
   }
   setTimeout(loop, 16);
+}
+
+
+
+if (typeof wx.onError === 'function') {
+  wx.onError((err) => {
+    reportRuntimeError('运行异常', err);
+  });
+}
+
+if (typeof wx.onUnhandledRejection === 'function') {
+  wx.onUnhandledRejection((err) => {
+    reportRuntimeError('异步异常', err);
+  });
 }
 
 adaptScreen();


### PR DESCRIPTION
### Motivation
- Prevent silent "Script error" and hard canvas initialization failures in different Tencent mini game runtimes and make in-game failures diagnosable.

### Description
- Add a `createGameCanvas()` helper that prefers `wx.createCanvas()` and falls back to `wx.createOffscreenCanvas()` and throws with a clear message if neither is available.
- Add `reportRuntimeError(prefix, err)` to extract `stack / errMsg / message`, set `statusText` for visible in-game feedback, and call `console.error` for diagnostics.
- Register `wx.onError` and `wx.onUnhandledRejection` to surface synchronous and asynchronous runtime errors rather than leaving them opaque.
- Ensure the error handlers are installed before `adaptScreen()`, `startNewGame()` and the main `loop()` so failures are reported early.

### Testing
- Ran a syntax check with `node -c minigame/game.js`, which succeeded.
- Ran a basic Sudoku engine smoke test with Node executing `newGame` and `check`, which returned expected results (`ok: true` and no conflicts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a0c192cc8321996ec0f125d0ace3)