### PR TITLE
fix(minigame): avoid header overlap on small screens

### DIFF
--- a/minigame/game.js
+++ b/minigame/game.js
@@ -21,6 +21,8 @@ let originX = 0;
 let originY = 0;
 let numButtons = [];
 let actionButtons = [];
+let titleX = 16;
+let titleY = 44;
 
 
 function reportRuntimeError(prefix, err) {
@@ -37,13 +39,19 @@ function adaptScreen() {
   ratio = sys.pixelRatio || 1;
   canvas.width = sys.windowWidth * ratio;
   canvas.height = sys.windowHeight * ratio;
-  ctx.scale(ratio, ratio);
+  ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
   const margin = 16;
+  const safeTop = sys.safeArea && Number.isFinite(sys.safeArea.top) ? sys.safeArea.top : 0;
+  const headerTop = Math.max(16, safeTop + 8);
+  titleX = margin;
+  titleY = headerTop + 18;
+  const actionTop = titleY + 16;
+
   gridSize = Math.min(sys.windowWidth - margin * 2, sys.windowHeight * 0.62);
   cellSize = gridSize / 9;
   originX = (sys.windowWidth - gridSize) / 2;
-  originY = 70;
+  originY = actionTop + 50;
 
   numButtons = [];
   const bw = (sys.windowWidth - margin * 2 - 16) / 5;
@@ -73,9 +81,9 @@ function adaptScreen() {
   });
 
   actionButtons = [
-    { label: '新局', action: 'new', x: margin, y: 18, w: 72, h: 34 },
-    { label: '提示', action: 'hint', x: margin + 82, y: 18, w: 72, h: 34 },
-    { label: '检查', action: 'check', x: margin + 164, y: 18, w: 72, h: 34 }
+    { label: '新局', action: 'new', x: margin, y: actionTop, w: 72, h: 34 },
+    { label: '提示', action: 'hint', x: margin + 82, y: actionTop, w: 72, h: 34 },
+    { label: '检查', action: 'check', x: margin + 164, y: actionTop, w: 72, h: 34 }
   ];
 }
 
@@ -196,7 +204,7 @@ function draw() {
 
   ctx.fillStyle = '#222';
   ctx.font = 'bold 18px sans-serif';
-  ctx.fillText('数独库 · 腾讯小游戏', 16, 44);
+  ctx.fillText('数独库 · 腾讯小游戏', titleX, titleY);
 
   ctx.font = '14px sans-serif';
   ctx.fillStyle = '#3b4a5a';


### PR DESCRIPTION
### Motivation
- Prevent the title and top action buttons from overlapping on devices with small screens or non-zero safe-area insets by computing header positions from the system `safeArea.top` value.
- Fix cumulative canvas scaling when `adaptScreen` is called multiple times by replacing `ctx.scale` with a deterministic transform.

### Description
- Update `minigame/game.js` to introduce `titleX` and `titleY` globals and compute `headerTop`/`actionTop` from `sys.safeArea.top` to place the title and action buttons using safe-area-aware vertical offsets.
- Move the Sudoku grid origin down (`originY` now set relative to `actionTop`) so the header and buttons no longer overlap the grid.
- Replace `ctx.scale(ratio, ratio)` with `ctx.setTransform(ratio, 0, 0, ratio, 0, 0)` to avoid cumulative scaling on repeated layout adaptations.
- Change action buttons y-coordinates to use the calculated `actionTop` and draw the title at `titleX,titleY`.

### Testing
- Ran `node minigame/lib/sudoku/tests/sudoku.test.js` which passed (`sudoku tests passed`).
- Performed a syntax/run check with `node -c minigame/game.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde50fb2388321b0e79de1d8648ee1)