### PR TITLE
feat: 强化数独通关反馈（大字 + 弹窗）

### DIFF
--- a/miniprogram/pages/sudoku/index.js
+++ b/miniprogram/pages/sudoku/index.js
@@ -46,6 +46,7 @@ Page({
     elapsedSec: 0,
     mistakeCount: 0,
     isSolved: false,
+    showVictoryModal: false,
     largeText: false,
     bigButtons: false,
     highContrast: false,
@@ -101,7 +102,11 @@ Page({
     const result = this.game.check();
     if (!result.ok) return this.showError(result.code);
     const statusText = result.isSolved ? '恭喜通关！' : result.conflicts.length ? '存在冲突，请检查红色格子' : '当前无冲突，继续加油！';
+    const wasSolved = this.data.isSolved;
     this.setData({ conflicts: result.conflicts, statusText, isSolved: result.isSolved });
+    if (result.isSolved && !wasSolved) {
+      this.showVictoryModal();
+    }
   },
 
   onTapHint() {
@@ -145,6 +150,7 @@ Page({
   syncFromResult(result, successText) {
     if (!result.ok) return this.showError(result.code);
     const state = result.state || this.game.getState();
+    const wasSolved = this.data.isSolved;
     this.setData({
       grid: state.grid,
       givensMask: state.givensMask,
@@ -154,7 +160,20 @@ Page({
       isSolved: state.isSolved,
       statusText: successText || (state.isSolved ? '恭喜通关！' : '继续加油！')
     });
+    if (state.isSolved && !wasSolved) {
+      this.showVictoryModal();
+    }
   },
+
+  showVictoryModal() {
+    this.setData({ showVictoryModal: true });
+  },
+
+  closeVictoryModal() {
+    this.setData({ showVictoryModal: false });
+  },
+
+  onTapDialog() {},
 
   showError(code) {
     this.setData({ statusText: ERROR_TEXT[code] || '操作失败' });

--- a/miniprogram/pages/sudoku/index.wxml
+++ b/miniprogram/pages/sudoku/index.wxml
@@ -26,6 +26,14 @@
 
   <view class="status-box">{{statusText}}</view>
 
+  <view wx:if="{{showVictoryModal}}" class="victory-mask" bindtap="closeVictoryModal">
+    <view class="victory-modal" catchtap="onTapDialog">
+      <view class="victory-title">🎉 恭喜通关！</view>
+      <view class="victory-desc">你太厉害了，数独完成！</view>
+      <button class="victory-btn" bindtap="closeVictoryModal">我知道了</button>
+    </view>
+  </view>
+
   <view class="grid-wrap">
     <view class="grid">
       <block wx:for="{{grid}}" wx:key="index">

--- a/miniprogram/pages/sudoku/index.wxss
+++ b/miniprogram/pages/sudoku/index.wxss
@@ -84,9 +84,54 @@ page {
   background: #dbe1ef;
   border-radius: 18rpx;
   padding: 22rpx;
-  font-size: 50rpx;
+  font-size: 56rpx;
   font-weight: 700;
   color: #1b2a4b;
+}
+
+.victory-mask {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 99;
+}
+
+.victory-modal {
+  width: 84%;
+  background: #fff;
+  border-radius: 24rpx;
+  padding: 44rpx 32rpx 34rpx;
+  box-shadow: 0 20rpx 60rpx rgba(0, 0, 0, 0.22);
+  text-align: center;
+}
+
+.victory-title {
+  font-size: 76rpx;
+  color: #1d4ed8;
+  font-weight: 900;
+  margin-bottom: 18rpx;
+}
+
+.victory-desc {
+  font-size: 46rpx;
+  color: #334155;
+  margin-bottom: 30rpx;
+}
+
+.victory-btn {
+  height: 90rpx;
+  border-radius: 16rpx;
+  background: #2563eb;
+  color: #fff;
+  font-size: 42rpx;
+  font-weight: 700;
+}
+
+.victory-btn::after {
+  border: none;
 }
 
 .grid-wrap {


### PR DESCRIPTION
### Motivation
- 提升数独通关的可见性：当玩家完成数独时，需要更醒目的提示（字体更大并弹出模态），确保用户能立刻看到“恭喜通关”。
- 避免通关提示被页面其他元素淹没，提供明确的关闭交互以恢复后续操作。

### Description
- 在 `miniprogram/pages/sudoku/index.js` 中新增 `showVictoryModal` 状态并添加 `showVictoryModal`、`closeVictoryModal` 与空的阻止冒泡方法 `onTapDialog`。
- 在 `syncFromResult` 与 `onTapCheck` 中加入“从未通关 -> 已通关”检测以触发弹窗，避免重复触发。
- 在 `miniprogram/pages/sudoku/index.wxml` 中新增通关弹层结构（遮罩、居中弹窗、标题、描述、确认按钮）并绑定关闭交互。
- 在 `miniprogram/pages/sudoku/index.wxss` 中增加弹层与弹窗样式并将顶部状态文字 `.status-box` 字号调大以提升可读性。

### Testing
- 运行单元测试：`node miniprogram/lib/sudoku/tests/sudoku.test.js`，测试通过并输出 `sudoku tests passed`。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde695f76483218ea5294dbe5f32e5)