### PR TITLE
feat(minigame): 支持分享到好友与朋友圈

### DIFF
--- a/minigame/game.js
+++ b/minigame/game.js
@@ -32,6 +32,51 @@ let difficultyButtons = [];
 let titleX = 16;
 let titleY = 44;
 let difficulty = 'beginner';
+const SHARE_IMAGE_URL = 'https://baduanjin.online/icon-512.png';
+
+function getDifficultyLabel(value = difficulty) {
+  return (DIFFICULTIES.find((item) => item.value === value) || {}).label || '入门';
+}
+
+function buildSharePayload(type = 'friend') {
+  const elapsed = formatElapsed(getElapsedSec());
+  const mistakes = state ? Number(state.mistakeCount || 0) : 0;
+  const diffLabel = getDifficultyLabel(difficulty);
+  const title = state && state.isSolved
+    ? `我在数独库通关了${diffLabel}难度，用时${elapsed}！`
+    : `来挑战数独库${diffLabel}难度，当前用时${elapsed}（错误${mistakes}/${MISTAKE_LIMIT}）`;
+  const query = `difficulty=${encodeURIComponent(difficulty)}&from=${type}`;
+
+  return {
+    title,
+    query,
+    imageUrl: SHARE_IMAGE_URL
+  };
+}
+
+function setupShareMenu() {
+  if (typeof wx.showShareMenu === 'function') {
+    wx.showShareMenu({
+      withShareTicket: true,
+      menus: ['shareAppMessage', 'shareTimeline']
+    });
+  }
+
+  if (typeof wx.onShareAppMessage === 'function') {
+    wx.onShareAppMessage(() => buildSharePayload('friend'));
+  }
+
+  if (typeof wx.onShareTimeline === 'function') {
+    wx.onShareTimeline(() => {
+      const payload = buildSharePayload('timeline');
+      return {
+        title: payload.title,
+        query: payload.query,
+        imageUrl: payload.imageUrl
+      };
+    });
+  }
+}
 
 function formatElapsed(sec) {
   const safe = Math.max(0, Number(sec) || 0);
@@ -128,7 +173,7 @@ function startNewGame(nextDifficulty = difficulty) {
   }
   state = result.state;
   selected = -1;
-  const diffLabel = (DIFFICULTIES.find((item) => item.value === difficulty) || {}).label || '入门';
+  const diffLabel = getDifficultyLabel(difficulty);
   statusText = `${diffLabel}难度开始，祝你通关！`;
 }
 
@@ -364,6 +409,7 @@ if (typeof wx.onUnhandledRejection === 'function') {
 }
 
 adaptScreen();
+setupShareMenu();
 startNewGame('beginner');
 loop();
 


### PR DESCRIPTION
### Motivation
- 允许微信小游戏直接转发给好友并分享到朋友圈，以便用户分享进度或邀友挑战。

### Description
- 在 `minigame/game.js` 中新增分享封面常量 `SHARE_IMAGE_URL`、难度文案函数 `getDifficultyLabel`、分享载荷构建函数 `buildSharePayload` 与初始化函数 `setupShareMenu`，并在启动时调用 `setupShareMenu`。
- `setupShareMenu` 会调用 `wx.showShareMenu` 并注册 `wx.onShareAppMessage` 与 `wx.onShareTimeline` 回调以分别支持“转发给好友”和“分享到朋友圈”。
- 分享文案会动态基于当前难度、用时、错误次数和是否通关生成，并在 `query` 中带上 `difficulty` 与来源标记以便追踪。
- 将原有难度文本抽取为 `getDifficultyLabel` 以减少重复代码，变更仅影响 `minigame/game.js` 文件。

### Testing
- 已执行单元测试：`node minigame/lib/sudoku/tests/sudoku.test.js`，测试通过（输出：`sudoku tests passed`）。
- 本次变更未影响题库与求解逻辑，未引入新的自动化失败。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de17aea5cc83219595fc32a5dca149)